### PR TITLE
fixed sed order in CHANGDEP definition for OSX and linux

### DIFF
--- a/module_xcommon/build/Makefile.common
+++ b/module_xcommon/build/Makefile.common
@@ -82,7 +82,7 @@ NULL=/dev/null
 CAT=cat
 OS=UNIX
 TO_OS=$(1)
-CHANGEDEP = sed $(TARGET_DIR)/$(notdir $1) -e "s/.*:/$(subst /,\/,$1 $(call TO_BUILD_DIR,$(call TO_OBJ, $2))):/g" -e "s/\.\.\//.\//g" -e "s/$(subst /,\/,$(abspath ..)/)/.\/..\//g"  > $1;$(call RM, $(TARGET_DIR)/$(notdir $1))
+CHANGEDEP = sed  -e "s/.*:/$(subst /,\/,$1 $(call TO_BUILD_DIR,$(call TO_OBJ, $2))):/g" -e "s/\.\.\//.\//g" -e "s/$(subst /,\/,$(abspath ..)/)/.\/..\//g" $(TARGET_DIR)/$(notdir $1) > $1;$(call RM, $(TARGET_DIR)/$(notdir $1))
 endif
 
 


### PR DESCRIPTION
Hi Dave,

There was a consistent error on OSX and almost certainly linux, with every dependency invocation.

In both systems the sed commands _precede_ the operand path. Before this fix the first dot of the '..etc' was causing the sed command processor to choke.

--r.
